### PR TITLE
Update ReflectionTypeHint.php - fix deprecation warning

### DIFF
--- a/src/Util/ReflectionTypeHint.php
+++ b/src/Util/ReflectionTypeHint.php
@@ -65,10 +65,11 @@ class ReflectionTypeHint
 
     public static function isValid()
     {
-        if (!assert_options(ASSERT_ACTIVE)) {
-            return true;
-        }
-        $bt = self::debugBacktrace(null, 1);
+		if ((int) ini_get('zend.assertions') <= 0) {
+    		return true;
+		}
+		
+		$bt = self::debugBacktrace(null, 1);
         $file = $line = $function = $class = $object = $type = $args = null;
         extract($bt);  //to $file, $line, $function, $class, $object, $type, $args
         /**


### PR DESCRIPTION
День добрый.

В текущей версии используется assert_options(ASSERT_ACTIVE) для отключения валидации параметров:

if (!assert_options(ASSERT_ACTIVE)) {
    return true;
}

Начиная с PHP 8.3 эта функция помечена как deprecated (в PHP 8.4 уже вызывает предупреждение), поэтому при использовании библиотеки появляются deprecation warnings.

Я заменил эту проверку на использование zend.assertions:

if ((int) ini_get('zend.assertions') <= 0) {
    return true;
}

Это полностью сохраняет исходное поведение:

zend.assertions = 1 — проверки выполняются
zend.assertions = 0 или -1 — проверки отключены (как и раньше)

Также это соответствует актуальным рекомендациям PHP по управлению assert’ами.

Спасибо!